### PR TITLE
Fix "SideCars" typo

### DIFF
--- a/stable/jenkins/Values/Master/Sidecars.dhall
+++ b/stable/jenkins/Values/Master/Sidecars.dhall
@@ -1,4 +1,4 @@
-let ConfigAutoReload = ./SideCars/ConfigAutoReload.dhall
+let ConfigAutoReload = ./Sidecars/ConfigAutoReload.dhall
 
 in  { Type = { configAutoReload : ConfigAutoReload.Type }
     , default = { configAutoReload = ConfigAutoReload.default }


### PR DESCRIPTION
Not sure what the correct spelling is. But the directory is named `Sidecars`.